### PR TITLE
Update to pull the module code from git instead of cvs

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -26,4 +26,4 @@ Using Drush Make:
 To use drush make download the file build.make. Then use the following command
 to build a development snapshot:
 
-drush make build.make
+drush make build.make www --working-copy

--- a/build.make
+++ b/build.make
@@ -6,4 +6,4 @@ projects[drupal][type] = core
 
 projects[commercedev][type] = "profile"
 projects[commercedev][download][type] = "git"
-projects[commercedev][download][url] = "http://github.com/rszrama/commercedev.git"
+projects[commercedev][download][url] = "git@github.com:cgthill/commercedev.git"

--- a/commercedev.info
+++ b/commercedev.info
@@ -54,8 +54,9 @@ dependencies[] = commerce_payment_example
 dependencies[] = commerce_price
 dependencies[] = commerce_product
 dependencies[] = commerce_product_ui
+dependencies[] = commerce_product_pricing
+dependencies[] = commerce_product_pricing_ui
 dependencies[] = commerce_product_reference
-dependencies[] = commerce_product_reference_ui
 dependencies[] = commerce_tax
 
 files[] = commercedev.profile

--- a/commercedev.info
+++ b/commercedev.info
@@ -58,5 +58,6 @@ dependencies[] = commerce_product_pricing
 dependencies[] = commerce_product_pricing_ui
 dependencies[] = commerce_product_reference
 dependencies[] = commerce_tax
+dependencies[] = commerce_tax_ui
 
 files[] = commercedev.profile

--- a/commercedev.install
+++ b/commercedev.install
@@ -567,8 +567,8 @@ function commercedev_install() {
   variable_set('admin_menu_tweak_modules', TRUE);
 
   // Give checkout access to anonymous and authenticated users.
-  user_role_grant_permissions(1, array('access checkout'));
-  user_role_grant_permissions(2, array('access checkout'));
+  user_role_grant_permissions(DRUPAL_ANONYMOUS_RID, array('access checkout'));
+  user_role_grant_permissions(DRUPAL_AUTHENTICATED_RID, array('access checkout', 'view own orders'));
 
   // Add a shortcut set for store administration.
   $set = new stdClass;

--- a/commercedev.install
+++ b/commercedev.install
@@ -517,6 +517,10 @@ function commercedev_install() {
     ),
 
     'display' => array(
+      'default' => array(
+        'label' => 'hidden',
+        'type' => 'commerce_cart_add_to_cart_form',
+      ),
       'full' => array(
         'label' => 'hidden',
         'type' => 'commerce_cart_add_to_cart_form',

--- a/commercedev.install
+++ b/commercedev.install
@@ -613,8 +613,8 @@ function commercedev_install() {
     $product->title = st('Product @num', array('@num' => $value));
     $product->uid = 1;
 
-    $product->purchase_price[LANGUAGE_NONE][0]['amount'] = $key * 10;
-    $product->purchase_price[LANGUAGE_NONE][0]['currency_code'] = 'USD';
+    $product->commerce_price[LANGUAGE_NONE][0]['amount'] = $key * 10;
+    $product->commerce_price[LANGUAGE_NONE][0]['currency_code'] = 'USD';
 
     $product = commerce_product_save($product);
 

--- a/commercedev.make
+++ b/commercedev.make
@@ -17,7 +17,10 @@ projects[rules][download][module] = contributions/modules/rules
 projects[rules][download][revision] = DRUPAL-7--2
 
 projects[addressfield][subdir] = contrib
-projects[addressfield][version] = 1.0-alpha1
+projects[addressfield][type] = module
+projects[addressfield][download][type] = cvs
+projects[addressfield][download][module] = contributions/modules/addressfield
+projects[addressfield][download][revision] = DRUPAL-7--1
 
 projects[commerce_paypal][subdir] = contrib
 projects[commerce_paypal][type] = module
@@ -27,12 +30,15 @@ projects[commerce_paypal][download][revision] = HEAD
 
 projects[ctools][subdir] = contrib
 projects[ctools][type] = module
+projects[ctools][download][type] = cvs
+projects[ctools][download][module] = contributions/modules/ctools
+projects[ctools][download][revision] = DRUPAL-7--1
 
 projects[views][subdir] = contrib
 projects[views][type] = module
 projects[views][download][type] = cvs
 projects[views][download][module] = contributions/modules/views
-projects[views][download][revision] = "DRUPAL-7--3"
+projects[views][download][revision] = DRUPAL-7--3
 
 projects[commerce][subdir] = contrib
 projects[commerce][type] = module

--- a/commercedev.make
+++ b/commercedev.make
@@ -3,36 +3,45 @@ core = 7.x
 
 projects[admin_menu][subdir] = contrib
 projects[admin_menu][type] = module
+projects[admin_menu][download][type] = git
+projects[admin_menu][download][url] = git://git.drupalcode.org/project/admin_menu.git
+projects[admin_menu][download][revision] = master
 
 projects[entity][subdir] = contrib
 projects[entity][type] = module
-projects[entity][download][type] = cvs
-projects[entity][download][module] = contributions/modules/entity
-projects[entity][download][revision] = DRUPAL-7--1
+projects[entity][download][type] = git
+projects[entity][download][url] = git://git.drupalcode.org/project/entity.git
+projects[entity][download][branch] = 7.x-1.x
 
 projects[rules][subdir] = contrib
 projects[rules][type] = module
-projects[rules][download][type] = cvs
-projects[rules][download][module] = contributions/modules/rules
-projects[rules][download][revision] = DRUPAL-7--2
+projects[rules][download][type] = git
+projects[rules][download][url] = git://git.drupalcode.org/project/rules.git
+projects[rules][download][branch] = 7.x-2.x
 
 projects[addressfield][subdir] = contrib
-projects[addressfield][version] = 1.0-alpha1
+projects[addressfield][type] = module
+projects[addressfield][download][type] = git
+projects[addressfield][download][url] = git://git.drupalcode.org/project/addressfield.git
+projects[addressfield][download][revision] = master
 
 projects[commerce_paypal][subdir] = contrib
 projects[commerce_paypal][type] = module
-projects[commerce_paypal][download][type] = cvs
-projects[commerce_paypal][download][module] = contributions/modules/commerce_paypal
-projects[commerce_paypal][download][revision] = HEAD
+projects[commerce_paypal][download][type] = git
+projects[commerce_paypal][download][url] = git://git.drupalcode.org/project/commerce_paypal.git
+projects[commerce_paypal][download][revision] = master
 
 projects[ctools][subdir] = contrib
 projects[ctools][type] = module
+projects[ctools][download][type] = git
+projects[ctools][download][url] = git://git.drupalcode.org/project/ctools.git
+projects[ctools][download][revision] = master
 
 projects[views][subdir] = contrib
 projects[views][type] = module
-projects[views][download][type] = cvs
-projects[views][download][module] = contributions/modules/views
-projects[views][download][revision] = "DRUPAL-7--3"
+projects[views][download][type] = git
+projects[views][download][url] = git://git.drupalcode.org/project/views.git
+projects[views][download][branch] = 7.x-3.x
 
 projects[commerce][subdir] = contrib
 projects[commerce][type] = module

--- a/commercedev.make
+++ b/commercedev.make
@@ -3,42 +3,45 @@ core = 7.x
 
 projects[admin_menu][subdir] = contrib
 projects[admin_menu][type] = module
+projects[admin_menu][download][type] = git
+projects[admin_menu][download][url] = git://git.drupalcode.org/project/admin_menu.git
+projects[admin_menu][download][revision] = master
 
 projects[entity][subdir] = contrib
 projects[entity][type] = module
-projects[entity][download][type] = cvs
-projects[entity][download][module] = contributions/modules/entity
-projects[entity][download][revision] = DRUPAL-7--1
+projects[entity][download][type] = git
+projects[entity][download][url] = git://git.drupalcode.org/project/entity.git
+projects[entity][download][branch] = 7.x-1.x
 
 projects[rules][subdir] = contrib
 projects[rules][type] = module
-projects[rules][download][type] = cvs
-projects[rules][download][module] = contributions/modules/rules
-projects[rules][download][revision] = DRUPAL-7--2
+projects[rules][download][type] = git
+projects[rules][download][url] = git://git.drupalcode.org/project/rules.git
+projects[rules][download][branch] = 7.x-2.x
 
 projects[addressfield][subdir] = contrib
 projects[addressfield][type] = module
-projects[addressfield][download][type] = cvs
-projects[addressfield][download][module] = contributions/modules/addressfield
-projects[addressfield][download][revision] = DRUPAL-7--1
+projects[addressfield][download][type] = git
+projects[addressfield][download][url] = git://git.drupalcode.org/project/addressfield.git
+projects[addressfield][download][revision] = master
 
 projects[commerce_paypal][subdir] = contrib
 projects[commerce_paypal][type] = module
-projects[commerce_paypal][download][type] = cvs
-projects[commerce_paypal][download][module] = contributions/modules/commerce_paypal
-projects[commerce_paypal][download][revision] = HEAD
+projects[commerce_paypal][download][type] = git
+projects[commerce_paypal][download][url] = git://git.drupalcode.org/project/commerce_paypal.git
+projects[commerce_paypal][download][revision] = master
 
 projects[ctools][subdir] = contrib
 projects[ctools][type] = module
-projects[ctools][download][type] = cvs
-projects[ctools][download][module] = contributions/modules/ctools
-projects[ctools][download][revision] = DRUPAL-7--1
+projects[ctools][download][type] = git
+projects[ctools][download][url] = git://git.drupalcode.org/project/ctools.git
+projects[ctools][download][revision] = master
 
 projects[views][subdir] = contrib
 projects[views][type] = module
-projects[views][download][type] = cvs
-projects[views][download][module] = contributions/modules/views
-projects[views][download][revision] = DRUPAL-7--3
+projects[views][download][type] = git
+projects[views][download][url] = git://git.drupalcode.org/project/views.git
+projects[views][download][branch] = 7.x-3.x
 
 projects[commerce][subdir] = contrib
 projects[commerce][type] = module


### PR DESCRIPTION
I don't think I need to explain myself, however i agree we want the masters or in some mosules cases the branch they are using,. However lets switch to git clones and move away from cvs.  

We aren't even putting CVS on our machines anymore.  :)

I update the readme to add the www directory and added the --working-copy so it does actual clones vs just downloading the code.  this way patches against the other modules can easily be made within the same file structure.
